### PR TITLE
Run `cargo diet` to reduce crate package size considerably

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 description = """
 Console tool for streamlining remote mobbing: timer, git sync, breaks and lunch
 """
+include = ["src/**/*", "README.md"]
 
 [[bin]]
 name = "mob"


### PR DESCRIPTION
Here is the output:

```
┌──────────────┬─────────────┐
│ Removed File │ Size (Byte) │
├──────────────┼─────────────┤
│ .gitignore   │          19 │
│ TODO.md      │          51 │
│ state.uml    │         323 │
│ Makefile     │         475 │
│ state.svg    │        5565 │
│ screen.gif   │     7193174 │
└──────────────┴─────────────┘
```

Saved 99% or 7.2 MB in 6 files (of 7.3 MB and 37 files in entire crate).