### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 categories = ["command-line-utilities"]
 keywords = ["cli"]
-homepage = "https://github.com/afajl/mob"
+repository = "https://github.com/afajl/mob"
 readme = "README.md"
 description = """
 Console tool for streamlining remote mobbing


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).